### PR TITLE
Se revierte la forma de parsear la fecha para los artículos

### DIFF
--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -21,18 +21,12 @@ class Article extends Component {
   }
 
   render() {
-    let creationDate = new Date(this.props.content.date)
-    creationDate = new Intl.DateTimeFormat('es-ES').format(creationDate)
-
-    let modificationDate = new Date(this.props.content.modified)
-    modificationDate = new Intl.DateTimeFormat('es-ES').format(modificationDate)
-
     return (<div className="article-container">
       <div className="article">
         <h1>{this.props.content.title.rendered}</h1>
         <div className="article-meta">
-          <span>Fecha de creación: {creationDate}</span>
-          <span>Fecha de modificación: {modificationDate}</span>
+          <span>Fecha de creación: {new Date(this.props.content.date).toLocaleDateString('es-ES')}</span>
+          <span>Fecha de modificación: {new Date(this.props.content.modified).toLocaleDateString('es-ES')}</span>
           <span>Autor: {this.props.authorName}</span>
         </div>
         {renderHTML(this.props.content.content.rendered)}


### PR DESCRIPTION
Este PR revierte la forma de mostrar la fecha en los artículos.

Se había cambiado a una lógica un poco más fea para probar una configuración en el servidor de CI. Ojalá funcione de la forma anterior como debería.