### PR TITLE
NOSTORY/cambiar-posicion-link-categoria

### DIFF
--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import PropTypes from 'prop-types'
 import renderHTML from 'react-render-html'
+import {Link} from 'react-router-dom'
 
 import CategoryContainer from '../Category/CategoryContainer'
 import ArticleNavigation from './ArticleNavigation'
@@ -20,9 +21,18 @@ class Article extends Component {
     })
   }
 
+  capitalizeString(str) {
+    return str ? str[0].toUpperCase() + str.substr(1).toLowerCase() : ''
+  }
+
   render() {
     return (<div className="article-container">
       <div className="article">
+
+        <div className="back-to-category">
+          <Link to={`/category/${this.props.categoryId}`}>&laquo; Volver a {this.capitalizeString(this.props.headerTitle)}</Link>
+        </div>
+
         <h1>{this.props.content.title.rendered}</h1>
         <div className="article-meta">
           <span>Fecha de creación: {new Date(this.props.content.date).toLocaleDateString('es-ES')}</span>
@@ -50,10 +60,12 @@ Article.propTypes = {
   dispatch: PropTypes.func.isRequired,
   authorName: PropTypes.string.isRequired,
   categoryId: PropTypes.number.isRequired,
-  articleId: PropTypes.number.isRequired
+  articleId: PropTypes.number.isRequired,
+  headerTitle: PropTypes.string.isRequired
 }
 
 export default connect(store => ({
   authorName: store.article.authorName,
   content: store.article.content,
+  headerTitle: store.header.title
 }))(Article)

--- a/src/components/Article/ArticleNavigation.js
+++ b/src/components/Article/ArticleNavigation.js
@@ -7,10 +7,6 @@ import './articleNavigation.scss'
 
 const ArticleNavigation = (props) => (
   <div className="article-navigation">
-    <div className="back-to-category">
-      <Link to={`/category/${props.categoryId}`}>&laquo; Volver a {capitalizeString(props.headerTitle)}</Link>
-    </div>
-
     <div className="previous-next-article">
       {getPreviousArticle(props.categoryId, props.articleId, props.articles, props.dispatch)}
       {getNextArticle(props.categoryId, props.articleId, props.articles, props.dispatch)}
@@ -22,8 +18,7 @@ ArticleNavigation.propTypes = {
   categoryId: PropTypes.number.isRequired,
   articleId: PropTypes.number.isRequired,
   articles: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  dispatch: PropTypes.func.isRequired,
-  headerTitle: PropTypes.string.isRequired
+  dispatch: PropTypes.func.isRequired
 }
 
 const getPreviousArticle = (categoryId, articleId, articles, dispatch) => {
@@ -62,11 +57,6 @@ const findArticleIndex = (articleId, articles) => {
   }
 }
 
-const capitalizeString = (str) => {
-  return str ? str[0].toUpperCase() + str.substr(1).toLowerCase() : ''
-}
-
 export default connect(store => ({
-  headerTitle: store.header.title,
   articles: store.category.articles
 }))(ArticleNavigation)

--- a/test/components/Article/article.test.js
+++ b/test/components/Article/article.test.js
@@ -49,6 +49,7 @@ const store = createStore(reducers)
 let wrapper
 
 beforeEach(() => {
+  store.dispatch({type: 'HEADER_SET_TITLE', payload: 'CATEGORY 1'})
   store.dispatch({type: 'CATEGORY_SET_ARTICLES', payload: articles})
   store.dispatch({type: 'ARTICLE_SET_CONTENT', payload: article1})
 
@@ -87,4 +88,10 @@ test('render article navigation for links', () => {
 
 test('render category container for other categories', () => {
   expect(wrapper.find('CategoryContainer').at(0).props()['title']).toEqual('OTRAS TEMÁTICAS')
+})
+
+test('render link for category of article', () => {
+  let link = wrapper.find('.article-container').find('.article').find('.back-to-category').find('Link')
+  expect(link.props()['to']).toEqual('/category/1')
+  expect(link.text()).toEqual('« Volver a Category 1')
 })

--- a/test/components/Article/articleNavigation.test.js
+++ b/test/components/Article/articleNavigation.test.js
@@ -47,7 +47,6 @@ const articles = [article1, article2, article3]
 
 const store = createStore(reducers)
 
-store.dispatch({type: 'HEADER_SET_TITLE', payload: 'CATEGORY 1'})
 store.dispatch({type: 'CATEGORY_SET_ARTICLES', payload: articles})
 
 const wrapper = mount(
@@ -60,12 +59,6 @@ const wrapper = mount(
 
 test('render outer div for article navigation', () => {
   expect(wrapper.find('.article-navigation')).toHaveLength(1)
-})
-
-test('render link for category of article', () => {
-  let link = wrapper.find('.article-navigation').find('.back-to-category').find('Link')
-  expect(link.props()['to']).toEqual('/category/1')
-  expect(link.text()).toEqual('« Volver a Category 1')
 })
 
 test('render link for previous and next article', () => {


### PR DESCRIPTION
Este PR cambia la posición del link para volver a la categoría de un artículo para mostrarlo sobre el título del mismo.