### PR TITLE
NOSTORY/hostear-header-en-aws

### DIFF
--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -1,7 +1,7 @@
 @import "src/utilities/_variables";
 
 header {
-  background: url('/assets/images/bannerpp3.png');
+  background: url('https://s3-sa-east-1.amazonaws.com/abacaxi-p3/frontend/assets/images/bannerpp3.png');
   background-size: cover;
   box-shadow: inset 2000px 0 0 0 rgba(0, 0, 0, 0.2);
 


### PR DESCRIPTION
Este PR cambia el link de la imagen del header para S3, con `Cache-Control`, evitando assets en Heroku