### PR TITLE
Nostory/fix assets heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest --coverage",
     "functional-test": "mocha -c --timeout 90000 --require babel-register --require test/hooks/css-modules-compiler.js --require babel-polyfill -r ./test/.setup.js --recursive ./test/functional",
     "test:watch": "yarn test -- --watch",
-    "postinstall": "postinstall-build dist --script build:prod"
+    "postinstall": "postinstall-build dist --script build:prod && cp -r ./assets/ ./dist/"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/src/components/Header/header.scss
+++ b/src/components/Header/header.scss
@@ -1,7 +1,7 @@
 @import "src/utilities/_variables";
 
 header {
-  background: url('https://s3-sa-east-1.amazonaws.com/abacaxi-p3/frontend/assets/images/bannerpp3.png');
+  background: url('/assets/images/bannerpp3.png');
   background-size: cover;
   box-shadow: inset 2000px 0 0 0 rgba(0, 0, 0, 0.2);
 

--- a/static.json
+++ b/static.json
@@ -2,7 +2,7 @@
   "root": "dist/",
   "https_only": true,
   "routes": {
-    "/assets/*": "/assets/",
+    "/assets/images/*": "/assets/images/",
     "/**": "index.html"
   },
   "proxies": {


### PR DESCRIPTION
Este PR configura nginx para cargar correctamente los assets de la aplicación y se vuelve a cargar el header desde assets, en vez de utilizar Amazon