### PR TITLE
NOSTORY/refactor-componente-article

### DIFF
--- a/redux/reducers/article/ArticleReducer.js
+++ b/redux/reducers/article/ArticleReducer.js
@@ -1,6 +1,5 @@
 const initialValues = {
   content: {},
-  authorName: ''
 }
 
 const ArticleReducer = (state = initialValues, action) => {
@@ -9,11 +8,6 @@ const ArticleReducer = (state = initialValues, action) => {
       return {
         ...state,
         content: action.payload
-      }
-    case 'ARTICLE_SET_AUTHOR':
-      return {
-        ...state,
-        authorName: action.payload
       }
     default:
       return state

--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -8,19 +8,11 @@ import CategoryContainer from '../Category/CategoryContainer'
 import ArticleNavigation from './ArticleNavigation'
 import Rating from '../Rating/Rating';
 
-import WordpressClient from '../../clients/WordpressClient'
-
 import './articleContainer.scss'
 import './article.scss'
 import '../Category/categoryContainer.scss'
 
 class Article extends Component {
-
-  componentDidMount() {
-    this.props.wordpressClient.getAuthorInfo(this.props.content.author).then(author => {
-      this.props.dispatch({type: 'ARTICLE_SET_AUTHOR', payload: author.data[0].name})
-    })
-  }
 
   capitalizeString(str) {
     return str ? str[0].toUpperCase() + str.substr(1).toLowerCase() : ''
@@ -39,7 +31,7 @@ class Article extends Component {
           <div className="article-meta">
             <span>Fecha de creación: {new Date(this.props.content.date).toLocaleDateString('es-ES')}</span>
             <span>Fecha de modificación: {new Date(this.props.content.modified).toLocaleDateString('es-ES')}</span>
-            <span>Autor: {this.props.authorName}</span>
+            <span>Autor: {this.props.content.author_name}</span>
           </div>
           {renderHTML(this.props.content.content.rendered)}
 
@@ -56,22 +48,14 @@ class Article extends Component {
 
 }
 
-Article.defaultProps = {
-  wordpressClient: new WordpressClient()
-}
-
 Article.propTypes = {
   content: PropTypes.shape().isRequired,
-  wordpressClient: PropTypes.shape().isRequired,
-  dispatch: PropTypes.func.isRequired,
-  authorName: PropTypes.string.isRequired,
   categoryId: PropTypes.number.isRequired,
   articleId: PropTypes.number.isRequired,
   headerTitle: PropTypes.string.isRequired
 }
 
 export default connect(store => ({
-  authorName: store.article.authorName,
   content: store.article.content,
   headerTitle: store.header.title
 }))(Article)

--- a/test/components/Article/article.test.js
+++ b/test/components/Article/article.test.js
@@ -20,7 +20,8 @@ const article1 = {
   post_meta_fields: {
     rating: 1.0,
     votes: 2
-  }
+  },
+  author_name: 'author1'
 }
 
 const article2 = {
@@ -32,22 +33,11 @@ const article2 = {
   },
   content: {
     rendered: 'excerpt2'
-  }
-}
-
-const authorInfo = {
-  data: [{
-    name: 'AuthorTest'
-  }]
+  },
+  author_name: 'author2'
 }
 
 const articles = [article1, article2]
-
-const wordpressClient = {
-  getAuthorInfo: (author) => {
-    return Promise.resolve(authorInfo)
-  }
-}
 
 const store = createStore(reducers)
 let wrapper
@@ -60,7 +50,7 @@ beforeEach(() => {
   wrapper = mount(
     <Provider store={store}>
       <MemoryRouter>
-        <Article categoryId={1} articleId={10} wordpressClient={wordpressClient} />
+        <Article categoryId={1} articleId={10} />
       </MemoryRouter>
     </Provider>
   )
@@ -78,7 +68,7 @@ test('render article meta', () => {
   let articleMeta = wrapper.find('.article-container').find('.article').find('.article-meta')
   expect(articleMeta.find('span').at(0).text()).toEqual('Fecha de creación: 2/2/2018')
   expect(articleMeta.find('span').at(1).text()).toEqual('Fecha de modificación: 4/2/2018')
-  expect(articleMeta.find('span').at(2).text()).toEqual('Autor: AuthorTest')
+  expect(articleMeta.find('span').at(2).text()).toEqual('Autor: author1')
 })
 
 test('render article html content', () => {


### PR DESCRIPTION
Este PR hace un refactor al componente `Article` para que no sea necesario enviar una nueva petición a la API para obtener el nombre del autor de un artículo.

Esto fue posible gracias a un cambio en la estructura de la API que devuelve el backend.